### PR TITLE
Some minor fixes

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -9,25 +9,33 @@ if ( function_exists( 'add_action' ) ) {
 	add_action(
 		'plugins_loaded',
 		function () {
-				if ( ! defined( 'USER_INTERACTION_SERVICE_BASE' ) ) {
-					define( 'USER_INTERACTION_SERVICE_BASE', 'https://hiive.cloud/workers/ai-proxy/' );
-				}
+			if ( ! defined( 'USER_INTERACTION_SERVICE_BASE' ) ) {
+				define( 'USER_INTERACTION_SERVICE_BASE', 'https://hiive.cloud/workers/ai-proxy/' );
+			}
 
 				register(
-					[
+					array(
 						'name'     => 'help-center',
 						'label'    => __( 'Help Center', 'newfold-help-center-module' ),
 						'callback' => function ( Container $container ) {
 							define( 'NFD_HELPCENTER_BUILD_DIR', __DIR__ . '/build/' );
 							define( 'NFD_HELPCENTER_PLUGIN_URL', $container->plugin()->url );
+							/*
+							 Do not load Help Center when in Onboarding (Onboarding has no admin bar to toggle this).
+							[TODO] Find a cleaner way to handle this.
+							*/
+							if ( isset( $_GET['page'] ) && 'nfd-onboarding' === sanitize_text_field( $_GET['page'] ) ) {
+								return;
+							}
+
 							new HelpCenter( $container );
 						},
 						'isActive' => true,
 						'isHidden' => true,
-					]
+					)
 				);
 
-			}
-		);
+		}
+	);
 
 }

--- a/includes/HelpCenter.php
+++ b/includes/HelpCenter.php
@@ -25,7 +25,7 @@ class HelpCenter {
     public function __construct( Container $container ) {
         $this->container = $container;
         add_action( 'rest_api_init', array( $this, 'initialize_rest' ) );
-        add_action( 'init', array( $this, 'register_assets') );
+        add_action( 'admin_init', array( $this, 'register_assets') );
         add_action( 'admin_bar_menu', array( $this, 'newfold_help_center' ), 11);
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -9,11 +9,13 @@ import Modal from "./components/Modal";
 import { ReactComponent as Help } from "./icons/help-plugin-sidebar-icon.svg";
 import { Analytics, LocalStorageUtils } from "./utils";
 
-HiiveAnalytics.initialize({
-  urls: {
-    single: window.nfdHelpCenter.restUrl + "/newfold-data/v1/events",
-  },
-});
+if ( window?.nfdHelpCenter?.restUrl ) {
+  HiiveAnalytics.initialize({
+    urls: {
+      single: window.nfdHelpCenter.restUrl + "/newfold-data/v1/events",
+    },
+  });
+}
 
 const wpContentContainer = document.getElementById("wpcontent");
 


### PR DESCRIPTION
1. Load help center only on admin pages.
2. Skip help center assets loading in Onboarding.
3. Check for `restUrl` before concatenation.