### PR TITLE
Initialize Analytics once DOM has loaded

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:e2e": "echo \"No tests implemented\""
   },
   "dependencies": {
-    "@newfold-labs/js-utility-ui-analytics": "1.0.0",
+    "@newfold-labs/js-utility-ui-analytics": "1.2.0",
     "@newfold-labs/wp-module-ai": "github:newfold-labs/js-utility-ai#1.0.0",
     "@wordpress/api-fetch": "6.20.0",
     "@wordpress/components": "23.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import { PluginSidebar } from "@wordpress/edit-post";
 import React, { render, useState, useEffect } from "@wordpress/element";
 import { registerPlugin } from "@wordpress/plugins";
+import domReady from '@wordpress/dom-ready';
 import { HiiveAnalytics } from "@newfold-labs/js-utility-ui-analytics";
 import { __ } from "@wordpress/i18n";
 import "../styles.scss";
@@ -9,13 +10,17 @@ import Modal from "./components/Modal";
 import { ReactComponent as Help } from "./icons/help-plugin-sidebar-icon.svg";
 import { Analytics, LocalStorageUtils } from "./utils";
 
-if (window?.nfdHelpCenter?.restUrl) {
-  HiiveAnalytics.initialize({
-    urls: {
-      single: window.nfdHelpCenter.restUrl + "/newfold-data/v1/events",
-    },
-  });
-}
+domReady(() => {
+  // Run only once DOM is ready, else this won't work.
+  if ( window?.nfdHelpCenter?.restUrl ) {
+    HiiveAnalytics.initialize({
+      namespace: 'nfd-help-center',
+      urls: {
+        single: window.nfdHelpCenter.restUrl + "/newfold-data/v1/events",
+      },
+    });
+  }
+})
 
 const wpContentContainer = document.getElementById("wpcontent");
 


### PR DESCRIPTION
Duplicate of https://github.com/newfold-labs/wp-module-help-center/pull/8, was cleaning up forks and ended up deleting that.