### PR TITLE
React 18 compatibility

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import React, { render, useState } from "@wordpress/element";
+import React, { createRoot, useState } from "@wordpress/element";
 import { __ } from "@wordpress/i18n";
 //
 import { PluginSidebar } from "@wordpress/edit-post";
@@ -85,14 +85,13 @@ window.newfoldEmbeddedHelp.renderEmbeddedHelp = function renderEmbeddedHelp() {
   wpContentContainer.appendChild(helpContainer);
   const DOM_TARGET = document.getElementById("nfd-help-center");
 
-  render(
-    <Modal
-      onClose={() => {
-        toggleHelp(false);
-        LocalStorageUtils.clear();
-      }}
-    />,
-    DOM_TARGET
+  createRoot(DOM_TARGET).render(
+      <Modal
+          onClose={() => {
+            toggleHelp(false);
+            LocalStorageUtils.clear();
+          }}
+      />
   );
 };
 


### PR DESCRIPTION
Fix the console error:

"Warning: ReactDOM.render is no longer supported in React 18. Use createRoot instead. Until you switch to the new API, your app will behave as if it's running React 17."