### PR TITLE
Avoid translating installed dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,7 @@
         "i18n-json": "rm -f languages/*.json && vendor/bin/wp i18n make-json ./languages --no-purge --pretty-print",
         "i18n-php": "vendor/bin/wp i18n make-php ./languages",
         "i18n-po": "vendor/bin/wp i18n update-po ./languages/wp-module-help-center.pot ./languages",
-        "i18n-pot": "vendor/bin/wp i18n make-pot .  --domain=wp-module-help-center ./languages/wp-module-help-center.pot --headers='{\"Report-Msgid-Bugs-To\":\"https://github.com/newfold-labs/wp-module-help-center/issues\",\"POT-Creation-Date\":\"2025-02-13T09:55:55+00:00\"}' --exclude=tests,src,vendor,node_modules,wordpress",
+        "i18n-pot": "vendor/bin/wp i18n make-pot . --domain=wp-module-help-center ./languages/wp-module-help-center.pot --headers='{\"Report-Msgid-Bugs-To\":\"https://github.com/newfold-labs/wp-module-help-center/issues\",\"POT-Creation-Date\":\"2025-02-13T09:55:55+00:00\"}' --exclude=tests,src,vendor,node_modules,wordpress",
         "lint": "vendor/bin/phpcs --standard=phpcs.xml -s .",
         "test": [
             "codecept run wpunit"

--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,7 @@
         "i18n-json": "rm -f languages/*.json && vendor/bin/wp i18n make-json ./languages --no-purge --pretty-print",
         "i18n-php": "vendor/bin/wp i18n make-php ./languages",
         "i18n-po": "vendor/bin/wp i18n update-po ./languages/wp-module-help-center.pot ./languages",
-        "i18n-pot": "vendor/bin/wp i18n make-pot . ./languages/wp-module-help-center.pot --headers='{\"Report-Msgid-Bugs-To\":\"https://github.com/newfold-labs/wp-module-help-center/issues\",\"POT-Creation-Date\":\"2025-02-13T09:55:55+00:00\"}' --exclude=tests,src,vendor,node_modules,wordpress",
+        "i18n-pot": "vendor/bin/wp i18n make-pot .  --domain=wp-module-help-center ./languages/wp-module-help-center.pot --headers='{\"Report-Msgid-Bugs-To\":\"https://github.com/newfold-labs/wp-module-help-center/issues\",\"POT-Creation-Date\":\"2025-02-13T09:55:55+00:00\"}' --exclude=tests,src,vendor,node_modules,wordpress",
         "lint": "vendor/bin/phpcs --standard=phpcs.xml -s .",
         "test": [
             "codecept run wpunit"

--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,7 @@
         "i18n-json": "rm -f languages/*.json && vendor/bin/wp i18n make-json ./languages --no-purge --pretty-print",
         "i18n-php": "vendor/bin/wp i18n make-php ./languages",
         "i18n-po": "vendor/bin/wp i18n update-po ./languages/wp-module-help-center.pot ./languages",
-        "i18n-pot": "vendor/bin/wp i18n make-pot . ./languages/wp-module-help-center.pot --headers='{\"Report-Msgid-Bugs-To\":\"https://github.com/newfold-labs/wp-module-help-center/issues\",\"POT-Creation-Date\":\"2025-02-13T09:55:55+00:00\"}' --exclude=tests,src",
+        "i18n-pot": "vendor/bin/wp i18n make-pot . ./languages/wp-module-help-center.pot --headers='{\"Report-Msgid-Bugs-To\":\"https://github.com/newfold-labs/wp-module-help-center/issues\",\"POT-Creation-Date\":\"2025-02-13T09:55:55+00:00\"}' --exclude=tests,src,vendor,node_modules,wordpress",
         "lint": "vendor/bin/phpcs --standard=phpcs.xml -s .",
         "test": [
             "codecept run wpunit"


### PR DESCRIPTION
## Proposed changes

This adds the missing `--domain` option to the `make-pot` command. Because WordPress is installed as a Composer dependency, this was resulting in all WordPress Core strings being sent over to Azure for translation and including them in language files only to never be used since Core does not use the module's text domain.

The default value for `--domain` is the project slug when `Text Domain` is not specified in the main plugin or theme file. Explicitly passing the text domain avoids the scenario where someone checks the repository out in a folder with a custom name.

This also adds the `vendor`, `node_modules`, and `wordpress` directories to the exclude list for the `make-pot` command. There should never be strings with in these directories with the module's text domain, so scanning and processing them is unnecessary.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

#### Production

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

<!-- Bugfixes should explain how to reproduce the bug -->

#### Development

- [ ] Tests
- [ ] Dependency update
- [ ] Environment update / refactoring
- [ ] Documentation Update

<!-- All PRs should endeavor to include tests -->
<!-- PRs with new tools or dependencies should explain how to use them -->

## Visual

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- On macOS press cmd+shift+3 to screenshot the entire screen, or cmd+shift+4 to select an area to capture -->
<!-- The screenshot will be saved to the desktop -->

<!-- Drag and drop the file(s) into the GitHub editor to attach -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- 
## Pre-deployment Checklist

- [ ] E.g. environmental variables which need to be set before deployment will work.
- [ ] E.g. other tickets which need to be complete before an API this change relies on will be ready
-->

<!--
## Post-deployment Checklist

How can the change be verified?

- [ ] E.g. temporarily enable logging and observe specific logs.
- [ ] E.g. observe new data in a specific view or table.
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
<!-- Now is a good time to create additional tickets for any necessary follow-up work. -->