### PR TITLE
Minimally scope permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -22,6 +22,7 @@ jobs:
     permissions:
       contents: write      # Required for the reusable translations workflow to push translation branch updates.
       pull-requests: write # Required for gh-based PR operations inside the reusable translations workflow.
+    timeout-minutes: 60
     uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
     with:
       text_domain: 'wp-module-help-center'

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -12,14 +12,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
 permissions: {}
 
 jobs:
   translate:
     name: 'Check and update translations'
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write      # Required for the reusable translations workflow to push translation branch updates.
+      pull-requests: write # Required for gh-based PR operations inside the reusable translations workflow.
     uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
     with:
       text_domain: 'wp-module-help-center'

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -19,6 +19,7 @@ jobs:
     name: Setup
     runs-on: ubuntu-latest
     permissions: {} # Derives branch name only; no checkout or GITHUB_TOKEN GitHub API usage.
+    timeout-minutes: 10
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -33,6 +34,7 @@ jobs:
     needs: setup
     permissions:
       contents: read # Required for the reusable Playwright workflow to check out the module and plugin.
+    timeout-minutes: 120
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     with:
       module-repo: ${{ github.repository }}
@@ -45,6 +47,7 @@ jobs:
     needs: setup
     permissions:
       contents: read # Required for the reusable Playwright workflow to check out the module and plugin.
+    timeout-minutes: 120
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     with:
       module-repo: ${{ github.repository }}
@@ -59,6 +62,7 @@ jobs:
     needs: setup
     permissions:
       contents: read # Required for the reusable Playwright workflow to check out the module and plugin.
+    timeout-minutes: 120
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     with:
       module-repo: ${{ github.repository }}
@@ -71,6 +75,7 @@ jobs:
     needs: setup
     permissions:
       contents: read # Required for the reusable Playwright workflow to check out the module and plugin.
+    timeout-minutes: 120
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     with:
       module-repo: ${{ github.repository }}

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -6,8 +6,9 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
@@ -17,6 +18,7 @@ jobs:
   setup:
     name: Setup
     runs-on: ubuntu-latest
+    permissions: {} # Derives branch name only; no checkout or GITHUB_TOKEN GitHub API usage.
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -29,6 +31,8 @@ jobs:
   bluehost:
     name: Bluehost Build and Test
     needs: setup
+    permissions:
+      contents: read # Required for the reusable Playwright workflow to check out the module and plugin.
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     with:
       module-repo: ${{ github.repository }}
@@ -39,6 +43,8 @@ jobs:
   bluehost-dev:
     name: Bluehost Dev Build and Test
     needs: setup
+    permissions:
+      contents: read # Required for the reusable Playwright workflow to check out the module and plugin.
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     with:
       module-repo: ${{ github.repository }}
@@ -51,6 +57,8 @@ jobs:
   hostgator:
     name: HostGator Build and Test
     needs: setup
+    permissions:
+      contents: read # Required for the reusable Playwright workflow to check out the module and plugin.
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     with:
       module-repo: ${{ github.repository }}
@@ -61,6 +69,8 @@ jobs:
   hostgator-dev:
     name: HostGator Dev Build and Test
     needs: setup
+    permissions:
+      contents: read # Required for the reusable Playwright workflow to check out the module and plugin.
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     with:
       module-repo: ${{ github.repository }}

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -13,12 +13,14 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   get-repo-name:
     runs-on: ubuntu-latest
+    permissions: {} # Job only derives a name from github.repository; no checkout or GitHub API access.
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -29,8 +31,8 @@ jobs:
   codecoverage:
     needs: get-repo-name
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write      # Required for the reusable workflow to push coverage reports to gh-pages.
+      pull-requests: write # Required for the reusable workflow to post PR comments and coverage comparisons.
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -21,6 +21,7 @@ jobs:
   get-repo-name:
     runs-on: ubuntu-latest
     permissions: {} # Job only derives a name from github.repository; no checkout or GitHub API access.
+    timeout-minutes: 30
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -33,6 +34,7 @@ jobs:
     permissions:
       contents: write      # Required for the reusable workflow to push coverage reports to gh-pages.
       pull-requests: write # Required for the reusable workflow to post PR comments and coverage comparisons.
+    timeout-minutes: 120
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -17,6 +17,7 @@ jobs:
     permissions:
       contents: write      # Required for Crowdin to commit downloaded translations (also sufficient for checkout read).
       pull-requests: write # Required for Crowdin to create or update the translation pull request when using GITHUB_TOKEN.
+    timeout-minutes: 60
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-download.yml@main
     with:
       base_branch: ${{ inputs.base_branch }}

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -8,12 +8,15 @@ on:
         required: false
         default: 'main'
 
-permissions:
-  contents: write
-  pull-requests: write
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   call-crowdin-workflow:
+    permissions:
+      contents: write      # Required for Crowdin to commit downloaded translations (also sufficient for checkout read).
+      pull-requests: write # Required for Crowdin to create or update the translation pull request when using GITHUB_TOKEN.
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-download.yml@main
     with:
       base_branch: ${{ inputs.base_branch }}

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       contents: write      # Required for Crowdin GitHub Action branch/commit operations using GITHUB_TOKEN.
       pull-requests: write # Required when Crowdin opens or updates pull requests for translation changes.
+    timeout-minutes: 60
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-upload.yml@main
     with:
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -3,8 +3,15 @@ name: Crowdin Upload Action
 on:
   workflow_dispatch:
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   call-crowdin-upload-workflow:
+    permissions:
+      contents: write      # Required for Crowdin GitHub Action branch/commit operations using GITHUB_TOKEN.
+      pull-requests: write # Required when Crowdin opens or updates pull requests for translation changes.
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-upload.yml@main
     with:
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,6 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read # Required to clone the private repository for PHPCS.
+    timeout-minutes: 30
     steps:
 
       - name: Checkout

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,10 +17,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   phpcs:
     name: Run PHP Code Sniffer
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to clone the private repository for PHPCS.
     steps:
 
       - name: Checkout

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -22,8 +22,8 @@ jobs:
   prep-release:
     name: Prepare Release
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write      # Required for the reusable workflow to clone, commit, and push the release branch.
+      pull-requests: write # Required for gh pr list and to create or update the release pull request.
     uses: newfold-labs/workflows/.github/workflows/reusable-module-prep-release.yml@main
     with:
       module-repo: ${{ github.repository }}

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -24,6 +24,7 @@ jobs:
     permissions:
       contents: write      # Required for the reusable workflow to clone, commit, and push the release branch.
       pull-requests: write # Required for gh pr list and to create or update the release pull request.
+    timeout-minutes: 60
     uses: newfold-labs/workflows/.github/workflows/reusable-module-prep-release.yml@main
     with:
       module-repo: ${{ github.repository }}

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -14,6 +14,7 @@ jobs:
     name: Send Webhook
     runs-on: ubuntu-latest
     permissions: {} # repository-dispatch uses secrets.WEBHOOK_TOKEN; GITHUB_TOKEN is not used for GitHub API calls.
+    timeout-minutes: 30
     steps:
 
       - name: Set Package

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -5,10 +5,15 @@ on:
     types:
       - created
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    permissions: {} # repository-dispatch uses secrets.WEBHOOK_TOKEN; GITHUB_TOKEN is not used for GitHub API calls.
     steps:
 
       - name: Set Package


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/WordPress/wordpress-playground/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

For more information, see [PRESS11-470](https://newfold.atlassian.net/browse/PRESS11-470).

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Cursor was used with (Claude Opus 4.7 and Composer 2.0 at varying points) to analyze the repository and make the initial changes.

When this PR is marked "ready for review" it means that I have manually reviewed all permissions and timeouts that were changed and made any necessary adjustments.

As a part of the analysis, the following summary was created:

## Status

| Field | Value |
|---|---|
| Workflows scanned | 8 (`auto-translate.yml`, `brand-plugin-test-playwright.yml`, `codecoverage-main.yml`, `i18n-crowdin-download.yml`, `i18n-crowdin-upload.yml`, `lint.yml`, `newfold-prep-release.yml`, `satis-update.yml`) |
| Branch | `add/scoped-workflow-permissions` (created) |
| Permissions commit | `42be13f` |
| Timeouts commit | `a94ed0e` |


## Top-level `permissions: {}`

| Category | Entry |
|---|---|
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `satis-update.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `lint.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `i18n-crowdin-upload.yml` |
| Workflows that already had `permissions: {}` but were missing the required two-line comment immediately above it (comments added in this run): | `auto-translate.yml` |
| Workflows that had a non-empty or non-compliant top-level `permissions` block and were converted to the required commented `permissions: {}` (added in this run): | `codecoverage-main.yml` (previously `contents: read`) |
| Workflows that had a non-empty or non-compliant top-level `permissions` block and were converted to the required commented `permissions: {}` (added in this run): | `brand-plugin-test-playwright.yml` (previously `contents: read`) |
| Workflows that had a non-empty or non-compliant top-level `permissions` block and were converted to the required commented `permissions: {}` (added in this run): | `i18n-crowdin-download.yml` (previously `contents: write` / `pull-requests: write` at workflow scope) |


## Job-level `permissions:` additions

| Workflow file | Summary | Job | Permissions / notes |
|---|---|---|---|
| satis-update.yml | 1 job was missing a scoped `permissions:` directive | webhook | `permissions: {}` [3] |
| lint.yml | 1 job was missing a scoped `permissions:` directive | phpcs | `contents: read` [3] |
| codecoverage-main.yml | 1 job was missing a scoped `permissions:` directive | get-repo-name | `permissions: {}` [3] |
| brand-plugin-test-playwright.yml | 5 jobs were missing a scoped `permissions:` directive | setup | `permissions: {}` [3] |
| brand-plugin-test-playwright.yml | 5 jobs were missing a scoped `permissions:` directive | bluehost | `contents: read` [3] |
| brand-plugin-test-playwright.yml | 5 jobs were missing a scoped `permissions:` directive | bluehost-dev | `contents: read` [3] |
| brand-plugin-test-playwright.yml | 5 jobs were missing a scoped `permissions:` directive | hostgator | `contents: read` [3] |
| brand-plugin-test-playwright.yml | 5 jobs were missing a scoped `permissions:` directive | hostgator-dev | `contents: read` [3] |
| i18n-crowdin-upload.yml | 1 job was missing a scoped `permissions:` directive | call-crowdin-upload-workflow | `contents: write`, `pull-requests: write` [2] |
| i18n-crowdin-download.yml | 1 job was missing a scoped `permissions:` directive (scopes moved from workflow-level to this job) | call-crowdin-workflow | `contents: write`, `pull-requests: write` [2] |


## Permissions corrections (previously incorrect)

| # | Correction |
|---:|---|
| 1 | `codecoverage-main.yml` :: `codecoverage`: BEFORE `contents: write` and `pull-requests: write` without per-permission comments -> AFTER the same scopes with trailing comments explaining gh-pages pushes and PR comments -- aligns with `reusable-codecoverage.yml` behavior -- [3] |
| 2 | `newfold-prep-release.yml` :: `prep-release`: BEFORE `contents: write` / `pull-requests: write` without comments -> AFTER the same scopes with trailing comments (clone/push/PR and `gh` usage in the reusable workflow) -- [3] |
| 3 | `auto-translate.yml` :: `translate`: BEFORE `contents: write` / `pull-requests: write` without comments -> AFTER the same scopes with trailing comments for the reusable translations workflow -- [2] |
| 4 | `i18n-crowdin-download.yml` :: `call-crowdin-workflow`: BEFORE workflow-level `contents: write` / `pull-requests: write` (no job-level grant for the reusable call) -> AFTER top-level `permissions: {}` plus job-level scopes with comments -- matches least-privilege pattern and reusable Crowdin download expectations -- [3] |


## `timeout-minutes` additions

| Workflow | Job | Minutes / action | Rationale |
|---|---|---|---|
| satis-update.yml | webhook | `30` | Repository dispatch is a short scripted job; this bounds runtime if the runner or network misbehaves. |
| newfold-prep-release.yml | prep-release | `60` | Release preparation can run install, build, and version bumps; an hour cap avoids a stuck workflow without matching any pre-existing timeout (none was present). |
| lint.yml | phpcs | `30` | PHPCS on a PHP diff is typically fast; thirty minutes is a safe ceiling for sporadic composer/cache delays. |
| codecoverage-main.yml | get-repo-name | `30` | The job only emits a variable; this is a low minute bound for a no-checkout helper job. |
| codecoverage-main.yml | codecoverage | `120` | The reusable matrix runs multiple PHP versions, tests, merges coverage, and may push to `gh-pages`; two hours allows full runs without altering any existing per-job timeout (none existed). |
| brand-plugin-test-playwright.yml | setup | `10` | Branch extraction is instantaneous; this only prevents a hung runner. |
| — | — | — | `brand-plugin-test-playwright.yml` :: `bluehost`, `bluehost-dev`, `hostgator`, `hostgator-dev` -> `120` each -- Playwright + `wp-env` integration builds are the longest jobs; two hours is a pragmatic ceiling versus unbounded runs. |
| i18n-crowdin-upload.yml | call-crowdin-upload-workflow | `60` | Crowdin upload can involve large file scans; one hour limits runaway uploads without an existing timeout. |
| i18n-crowdin-download.yml | call-crowdin-workflow | `60` | Crowdin download and optional PR creation can take time on large locales; one hour bounds the call. |
| auto-translate.yml | translate | `60` | The reusable translations workflow may run composer/npm and Azure translation; one hour caps worst-case loops. |


## Notes / blockers

| # | Note |
|---:|---|
| 1 | `i18n-crowdin-download.yml` only passes `CROWDIN_PERSONAL_TOKEN` into `newfold-labs/workflows` `i18n-crowdin-download.yml@main`, while the upstream reusable workflow also declares a required `NEWFOLD_ACCESS_TOKEN` secret for `GITHUB_TOKEN` in the Crowdin action. Confirm that secret mapping is provided organization-wide or add an explicit `secrets:` mapping in this workflow if runs fail at that step. [2] |
| 2 | Crowdin upload/download jobs use scopes `contents: write` and `pull-requests: write` to satisfy `crowdin/github-action` GitHub integration patterns seen in the reusable workflows; if your organization uses only a PAT via `env` and disables default-token features, you may be able to tighten further after observing real token use. [2] |


