### PR TITLE
Hide help center on block editor and site editor screens (PRESS0-4504)

### DIFF
--- a/includes/HelpCenter.php
+++ b/includes/HelpCenter.php
@@ -128,11 +128,41 @@ class HelpCenter {
 	}
 
 	/**
+	 * Whether the current admin screen is one we deliberately skip the help center on.
+	 *
+	 * The block editor (Gutenberg post/page edit) and the site editor (FSE) host their
+	 * own AI chat surface that shares the wp-module-ai-chat framework with us; mounting
+	 * the help center there too would put two AI panels on the same screen.
+	 *
+	 * @return bool True when the current screen is the block editor or site editor.
+	 */
+	private function is_excluded_screen() {
+		if ( ! function_exists( 'get_current_screen' ) ) {
+			return false;
+		}
+		$screen = \get_current_screen();
+		if ( ! $screen ) {
+			return false;
+		}
+		if ( method_exists( $screen, 'is_block_editor' ) && $screen->is_block_editor() ) {
+			return true;
+		}
+		// `site-editor.php` reports base/id as `site-editor` in WP 6.x.
+		if ( 'site-editor' === $screen->base || 'site-editor' === $screen->id ) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
 	 * Adds the Help Center icon to the WordPress admin bar.
 	 *
 	 * @param \WP_Admin_Bar $admin_bar The WordPress Admin Bar instance.
 	 */
 	public function newfold_help_center( \WP_Admin_Bar $admin_bar ) {
+		if ( $this->is_excluded_screen() ) {
+			return;
+		}
 		if ( current_user_can( 'manage_options' ) && is_admin() ) {
 			$help_icon        =
 			'<svg width="24" height="24" viewBox="0 0 24 24" fill="#fff" xmlns="http://www.w3.org/2000/svg" style="margin-top: 5px;">
@@ -161,6 +191,9 @@ class HelpCenter {
 	 * Load WP dependencies into the page.
 	 */
 	public function assets() {
+		if ( $this->is_excluded_screen() ) {
+			return;
+		}
 		$dir          = container()->plugin()->url . 'vendor/newfold-labs/wp-module-help-center/';
 		$asset_file   = NFD_HELPCENTER_BUILD_DIR . 'index.asset.php';
 		$help_enabled = $this->container->get( 'capabilities' )->get( 'canAccessHelpCenter' );


### PR DESCRIPTION
Both screens will host their own AI chat backed by the wp-module-ai-chat framework; mounting the help center there too would put two AI panels on the same page. Add an is_excluded_screen() helper and short-circuit the asset enqueue and admin-bar entry when WP_Screen::is_block_editor() is true or the screen base/id is site-editor. REST routes, text-domain loading, and the capability gate are unaffected.

## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

#### Production

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

<!-- Bugfixes should explain how to reproduce the bug -->

#### Development

- [ ] Tests
- [ ] Dependency update
- [ ] Environment update / refactoring
- [ ] Documentation Update

<!-- All PRs should endeavor to include tests -->
<!-- PRs with new tools or dependencies should explain how to use them -->

## Visual

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- On macOS press cmd+shift+3 to screenshot the entire screen, or cmd+shift+4 to select an area to capture -->
<!-- The screenshot will be saved to the desktop -->

<!-- Drag and drop the file(s) into the GitHub editor to attach -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- 
## Pre-deployment Checklist

- [ ] E.g. environmental variables which need to be set before deployment will work.
- [ ] E.g. other tickets which need to be complete before an API this change relies on will be ready
-->

<!--
## Post-deployment Checklist

How can the change be verified?

- [ ] E.g. temporarily enable logging and observe specific logs.
- [ ] E.g. observe new data in a specific view or table.
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
<!-- Now is a good time to create additional tickets for any necessary follow-up work. -->