### PR TITLE
Gate welcome-screen suggestions on site context (PRESS0-4509)

### DIFF
--- a/includes/HelpCenter.php
+++ b/includes/HelpCenter.php
@@ -188,6 +188,26 @@ class HelpCenter {
 	}
 
 	/**
+	 * Build the environment flags shipped to the JS bundle via the inline `nfdHelpCenter` global.
+	 *
+	 * Drives client-side gating (e.g. welcome-screen suggestions). The JS reads this object via
+	 * `getHelpCenterEnv()` and suggestions opt in with a `requires` predicate. Add new booleans
+	 * here for future integrations; mirror the default in `helpCenterEnv.js`. All values are
+	 * booleans — the JS-side env reader spreads this object over typed defaults.
+	 *
+	 * Extracted from `assets()` so it can be unit-tested without standing up the full enqueue flow.
+	 *
+	 * @internal Stable signature for tests and the JS bundle; not intended as a public extension point.
+	 *
+	 * @return array Map of flag name to boolean value.
+	 */
+	public static function get_js_environment() {
+		return array(
+			'hasWooCommerce' => class_exists( 'WooCommerce' ),
+		);
+	}
+
+	/**
 	 * Load WP dependencies into the page.
 	 */
 	public function assets() {
@@ -234,6 +254,7 @@ class HelpCenter {
 							'resourceLink'             => Brands::get_resource_link_for_brand( NFD_HELPCENTER_PLUGIN_BRAND ),
 							'brand'                    => NFD_HELPCENTER_PLUGIN_BRAND,
 							'brandConfig'              => $brand_data,
+							'environment'              => self::get_js_environment(),
 							/* translators: 1: account name, 2: phone link, 3: chat link */
 							'supportMessageTemplate'   => __( 'If you need help with your %1$s account, give us a call at %2$s or %3$s with one of our support agents — we\'re here for you!', 'wp-module-help-center' ),
 							/* translators: 1: account name, 2: chat link */

--- a/src/constants/welcomeSuggestions.js
+++ b/src/constants/welcomeSuggestions.js
@@ -1,13 +1,19 @@
 /**
  * Welcome screen quick-start suggestions.
  *
- * Each suggestion is `{ id, icon, text, action }` where `action` is the prompt sent to the AI
- * (text shown to the user is `text`). Kept as a function so localized strings re-evaluate on
- * locale change rather than freezing at module-load.
+ * Each suggestion is `{ id, icon, text, action, slot?, requires? }`:
+ * - `action` is the prompt sent to the AI (text shown to the user is `text`).
+ * - `requires(env)` is an optional predicate gating the entry against `HelpCenterEnv` flags
+ *   emitted by PHP. Entries without `requires` always match.
+ * - `slot` is an optional string identifier; entries sharing a slot compete and at most one
+ *   renders. Predicate-having entries always win over catch-alls (entries without
+ *   `requires`), regardless of declaration order — so contributors don't have to remember
+ *   to list catch-alls last. The rendered tile takes the winner's position in the list.
  */
 
 import { __ } from '@wordpress/i18n';
-import { Icon, pencil, page, box, cog } from '@wordpress/icons';
+import { Icon, pencil, page, box, brush, cog } from '@wordpress/icons';
+import { getHelpCenterEnv } from '../utils/helpCenterEnv';
 
 const ICON_SIZE = 16;
 
@@ -15,15 +21,24 @@ const renderIcon = (glyph) => (
 	<Icon icon={glyph} size={ICON_SIZE} />
 );
 
+// Slot ID for the contextual action tile (Add-a-product for WooCommerce stores, otherwise
+// Customize-site). Extracted so the two peer entries can't drift out of sync on rename.
+const SLOT_CONTEXTUAL_ACTION = 'contextual-action';
+
 /**
- * Default welcome-screen quick-start suggestions for the AI help center.
+ * Master list of welcome-screen suggestions in display order.
  *
- * The shape matches what `WelcomeScreen` (from wp-module-ai-chat) expects in its `suggestions`
- * prop. Add or reorder freely; ids are used as React keys.
+ * Frozen at module-load. WP admin locale is fixed per request, so re-evaluating `__()` per
+ * call gains nothing in practice and the upstream `useMemo([])` freezes the result anyway.
  *
- * @return {Array<{id: string, icon: JSX.Element, text: string, action: string}>}
+ * Adding a conditional swap: list both entries with the same `slot`, give the conditional
+ * one a `requires` predicate, leave the catch-all without one. Declaration order between
+ * the two is irrelevant — the resolver picks predicate-match first.
+ *
+ * Adding a new env flag: extend `HelpCenter::get_js_environment()` on the PHP side, mirror
+ * the default in `helpCenterEnv.js`, then reference it from a `requires` predicate here.
  */
-export const getWelcomeSuggestions = () => [
+const ALL_SUGGESTIONS = [
 	{
 		id: 'write-post',
 		icon: renderIcon(pencil),
@@ -41,6 +56,15 @@ export const getWelcomeSuggestions = () => [
 		icon: renderIcon(box),
 		text: __('Add a product', 'wp-module-help-center'),
 		action: __('Add a new product to my store.', 'wp-module-help-center'),
+		slot: SLOT_CONTEXTUAL_ACTION,
+		requires: (env) => env.hasWooCommerce,
+	},
+	{
+		id: 'customize-site',
+		icon: renderIcon(brush),
+		text: __('Customize site', 'wp-module-help-center'),
+		action: __('Help me customize my site\'s appearance.', 'wp-module-help-center'),
+		slot: SLOT_CONTEXTUAL_ACTION,
 	},
 	{
 		id: 'site-settings',
@@ -49,3 +73,80 @@ export const getWelcomeSuggestions = () => [
 		action: __('Help me update my site settings.', 'wp-module-help-center'),
 	},
 ];
+
+/**
+ * Pick the winning entry for one slot. Predicate-match wins over catch-all regardless of
+ * declaration order; ties between multiple matching predicates are broken by first occurrence.
+ *
+ * @param {Array}                                                         entries Entries in the slot, in master-list order.
+ * @param {import('../utils/helpCenterEnv').HelpCenterEnv}                env     Current env flags.
+ * @return {Object|null} The winning entry, or null if the slot has no viable entry.
+ */
+const resolveSlotWinner = (entries, env) => {
+	let firstMatchingPredicate = null;
+	let firstCatchAll = null;
+	for (const entry of entries) {
+		if (typeof entry.requires === 'function') {
+			if (!firstMatchingPredicate && entry.requires(env)) {
+				firstMatchingPredicate = entry;
+			}
+		} else if (!firstCatchAll) {
+			firstCatchAll = entry;
+		}
+	}
+	return firstMatchingPredicate || firstCatchAll || null;
+};
+
+/**
+ * Resolved welcome-screen suggestions for the current site environment.
+ *
+ * Two-phase resolution: first pick each slot's winner (predicate-first, catch-all fallback),
+ * then walk the master list and emit non-slot entries whose predicate matches plus each
+ * slot's winner at its declared position. `requires`/`slot` are stripped from the returned
+ * objects so the presentational `WelcomeScreen` (in wp-module-ai-chat) stays unaware of
+ * gating logic.
+ *
+ * @return {Array<{id: string, icon: JSX.Element, text: string, action: string}>}
+ */
+export const getWelcomeSuggestions = () => {
+	const env = getHelpCenterEnv();
+
+	const entriesBySlot = new Map();
+	for (const suggestion of ALL_SUGGESTIONS) {
+		if (!suggestion.slot) {
+			continue;
+		}
+		if (!entriesBySlot.has(suggestion.slot)) {
+			entriesBySlot.set(suggestion.slot, []);
+		}
+		entriesBySlot.get(suggestion.slot).push(suggestion);
+	}
+
+	const winnerBySlot = new Map();
+	for (const [slot, entries] of entriesBySlot) {
+		const winner = resolveSlotWinner(entries, env);
+		if (winner) {
+			winnerBySlot.set(slot, winner);
+		}
+	}
+
+	const emittedSlots = new Set();
+	const resolved = [];
+	for (const suggestion of ALL_SUGGESTIONS) {
+		if (suggestion.slot) {
+			if (emittedSlots.has(suggestion.slot)) {
+				continue;
+			}
+			if (winnerBySlot.get(suggestion.slot) !== suggestion) {
+				continue;
+			}
+			emittedSlots.add(suggestion.slot);
+		} else if (typeof suggestion.requires === 'function' && !suggestion.requires(env)) {
+			continue;
+		}
+		const { requires, slot, ...rest } = suggestion;
+		resolved.push(rest);
+	}
+
+	return resolved;
+};

--- a/src/utils/helpCenterEnv.js
+++ b/src/utils/helpCenterEnv.js
@@ -1,0 +1,28 @@
+/**
+ * Reader for the `nfdHelpCenter.environment` flags emitted by PHP.
+ *
+ * PHP populates `window.nfdHelpCenter.environment` in `HelpCenter::assets()` with booleans
+ * describing the host site (e.g. whether WooCommerce is active). The shape lives in one place
+ * here so callers don't sprinkle `window.nfdHelpCenter?.environment?.xxx` reads across the
+ * codebase. Add a new flag by extending PHP's `environment` array and giving it a default below.
+ *
+ * @typedef {Object} HelpCenterEnv
+ * @property {boolean} hasWooCommerce Whether WooCommerce is active on the site.
+ */
+
+const DEFAULTS = Object.freeze({
+	hasWooCommerce: false,
+});
+
+/**
+ * Return the current help-center environment flags, with defaults for anything missing.
+ *
+ * @return {HelpCenterEnv} Normalized environment object.
+ */
+export const getHelpCenterEnv = () => {
+	const env = (typeof window !== 'undefined' && window.nfdHelpCenter && window.nfdHelpCenter.environment) || {};
+	return {
+		...DEFAULTS,
+		...env,
+	};
+};

--- a/tests/wpunit/HelpCenterEnvironmentWPUnitTest.php
+++ b/tests/wpunit/HelpCenterEnvironmentWPUnitTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace NewfoldLabs\WP\Module\HelpCenter;
+
+/**
+ * HelpCenter::get_js_environment() wpunit tests.
+ *
+ * Verifies the structure and contract of the environment flags emitted to the JS bundle.
+ * These flags drive welcome-screen suggestion gating (e.g. hiding "Add a product" when
+ * WooCommerce is absent), so the contract here is what every client predicate relies on.
+ *
+ * The "true" path for hasWooCommerce isn't asserted directly because defining a
+ * `WooCommerce` class via class_alias leaks across tests in the shared wpunit process.
+ * Instead we assert the relationship — the flag tracks class_exists() — which is the
+ * invariant we actually care about and is robust regardless of which classes are loaded.
+ *
+ * @coversDefaultClass \NewfoldLabs\WP\Module\HelpCenter\HelpCenter
+ */
+class HelpCenterEnvironmentWPUnitTest extends \lucatume\WPBrowser\TestCase\WPTestCase {
+
+	/**
+	 * The method returns an array containing the documented flag keys.
+	 *
+	 * @return void
+	 */
+	public function test_returns_array_with_known_flags() {
+		$env = HelpCenter::get_js_environment();
+
+		$this->assertIsArray( $env );
+		$this->assertArrayHasKey( 'hasWooCommerce', $env );
+	}
+
+	/**
+	 * Every flag value is a real boolean, not a truthy/falsy scalar. The JS side spreads
+	 * this object over typed defaults, so non-boolean values would silently corrupt the
+	 * env shape.
+	 *
+	 * @return void
+	 */
+	public function test_flag_values_are_booleans() {
+		$env = HelpCenter::get_js_environment();
+
+		foreach ( $env as $key => $value ) {
+			$this->assertIsBool( $value, "Flag '{$key}' must be a boolean." );
+		}
+	}
+
+	/**
+	 * hasWooCommerce mirrors class_exists( 'WooCommerce' ). This is the load-bearing
+	 * contract; the JS welcome-screen gating assumes exactly this relationship.
+	 *
+	 * @return void
+	 */
+	public function test_has_woocommerce_mirrors_class_exists() {
+		$env = HelpCenter::get_js_environment();
+
+		$this->assertSame( class_exists( 'WooCommerce' ), $env['hasWooCommerce'] );
+	}
+
+	/**
+	 * In the wpunit environment WooCommerce is not installed, so the flag must be false.
+	 * Skips defensively if a future test setup pre-loads WooCommerce, since the absent
+	 * path is what we want to lock in here.
+	 *
+	 * @return void
+	 */
+	public function test_has_woocommerce_false_without_class() {
+		if ( class_exists( 'WooCommerce' ) ) {
+			$this->markTestSkipped( 'WooCommerce class is present in this test run; absent-path assertion skipped.' );
+		}
+
+		$env = HelpCenter::get_js_environment();
+
+		$this->assertFalse( $env['hasWooCommerce'] );
+	}
+}

--- a/tests/wpunit/HelpCenterEnvironmentWPUnitTest.php
+++ b/tests/wpunit/HelpCenterEnvironmentWPUnitTest.php
@@ -46,8 +46,8 @@ class HelpCenterEnvironmentWPUnitTest extends \lucatume\WPBrowser\TestCase\WPTes
 	}
 
 	/**
-	 * hasWooCommerce mirrors class_exists( 'WooCommerce' ). This is the load-bearing
-	 * contract; the JS welcome-screen gating assumes exactly this relationship.
+	 * Verifies hasWooCommerce mirrors class_exists( 'WooCommerce' ). This is the
+	 * load-bearing contract; the JS welcome-screen gating assumes exactly this relationship.
 	 *
 	 * @return void
 	 */


### PR DESCRIPTION
The AI help center welcome screen was showing "Add a product" to every admin regardless of WooCommerce being active, sending users into chats about a feature they don't have. This change gates the tile behind a class_exists('WooCommerce') check and substitutes "Customize site" when WooCommerce is absent, so four relevant tiles always render in the same 1+2+1 layout.

Introduces a small, scalable seam for future swaps:

- PHP exposes site-context booleans via a new nfdHelpCenter.environment object built by HelpCenter::get_js_environment(). Marked @internal: stable signature for tests and the JS bundle, not a public extension point.
- JS reads those flags through getHelpCenterEnv() and gates each suggestion with an optional requires(env) predicate. A slot mechanism lets peer suggestions compete for one position; predicate-match always beats catch-all regardless of declaration order, so the tile count stays stable.
- Adds wpunit coverage (HelpCenterEnvironmentWPUnitTest) pinning the env builder contract: hasWooCommerce mirrors class_exists('WooCommerce'), return shape is array of booleans.

Adding a future gated tile (e.g. an SEO-plugin-specific suggestion) is: one boolean in get_js_environment(), one default in helpCenterEnv.js, one suggestion entry with a requires predicate. No changes needed in the shared wp-module-ai-chat package.

## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

#### Production

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

<!-- Bugfixes should explain how to reproduce the bug -->

#### Development

- [ ] Tests
- [ ] Dependency update
- [ ] Environment update / refactoring
- [ ] Documentation Update

<!-- All PRs should endeavor to include tests -->
<!-- PRs with new tools or dependencies should explain how to use them -->

## Visual

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- On macOS press cmd+shift+3 to screenshot the entire screen, or cmd+shift+4 to select an area to capture -->
<!-- The screenshot will be saved to the desktop -->

<!-- Drag and drop the file(s) into the GitHub editor to attach -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- 
## Pre-deployment Checklist

- [ ] E.g. environmental variables which need to be set before deployment will work.
- [ ] E.g. other tickets which need to be complete before an API this change relies on will be ready
-->

<!--
## Post-deployment Checklist

How can the change be verified?

- [ ] E.g. temporarily enable logging and observe specific logs.
- [ ] E.g. observe new data in a specific view or table.
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
<!-- Now is a good time to create additional tickets for any necessary follow-up work. -->